### PR TITLE
Fixed env.example and added missing redis host value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ POSTGRES_DB=iot_database
 POSTGRES_PORT=5432
 
 # Redis Configuration
+REDIS_HOST=redis
 REDIS_PORT=6379
 REDIS_PASSWORD=password
 


### PR DESCRIPTION
- Added missing Redis host value to .env.example file